### PR TITLE
EI-510 - RestResolver: fix nil ResolverError when not found

### DIFF
--- a/pkg/register/restResolver.go
+++ b/pkg/register/restResolver.go
@@ -87,7 +87,7 @@ func (c *RestResolverClient) GetDocument(documentID string) (*RegisterDocument, 
 
 	if response.StatusCode == http.StatusNotFound {
 		totalResolverErrors.WithLabelValues(MetricErrorTypeNotFound).Inc()
-		return nil, &ResolverError{err: err, errType: NotFound}
+		return nil, &ResolverError{err: fmt.Errorf("%s: document %s", http.StatusText(http.StatusNotFound), documentID), errType: NotFound}
 	}
 
 	data, err := ioutil.ReadAll(response.Body)

--- a/pkg/register/restResolver_test.go
+++ b/pkg/register/restResolver_test.go
@@ -94,6 +94,9 @@ func Test_Resolver_Notfound_Error(t *testing.T) {
 	assert.Assert(t, register.IsResolverError(err))
 	re := err.(*register.ResolverError)
 	assert.Equal(t, re.ErrorType(), register.NotFound)
+	assert.Assert(t, re.Err() != nil)
+	assert.ErrorContains(t, re.Err(), fmt.Sprintf("document %s", ValidID))
+	assert.ErrorContains(t, re.Err(), http.StatusText(http.StatusNotFound))
 
 	expected := `# HELP iotics_identity_resolver_errors_total Total resolver client errors by error type
 	# TYPE iotics_identity_resolver_errors_total counter


### PR DESCRIPTION
In RestResolver here https://github.com/Iotic-Labs/iotics-identity-go/blob/4d2824b34c831c7bd99da874fcd72e6d960a9c28/pkg/register/restResolver.go#L90
The wrapped error is nil. To be consistent it should not be nil but contains the httpsattus text like the other one