### PR TITLE
Detect OS and architecture to allow building on macOS/non-amd64 systems

### DIFF
--- a/ffi/Makefile
+++ b/ffi/Makefile
@@ -1,9 +1,25 @@
+UNAME_OS := $(shell uname -s)
+ifeq ($(UNAME_OS),Darwin)
+	OS_FLAG=darwin
+endif
+ifeq ($(UNAME_OS),Linux)
+	OS_FLAG=linux
+endif
+
+UNAME_ARCH := $(shell uname -s)
+ifeq ($(UNAME_ARCH),i386)
+	ARCH_FLAG=i386
+endif
+ifeq ($(UNAME_ARCH),amd64)
+	ARCH_FLAG=amd64
+endif
+
 clean:
 	@rm -rf bin go.mod go.sum
 
 GO_SRC=./ffi_wrapper.go
 
 compile:
-	@env GOOS=linux GOARCH=amd64 go build -buildmode=c-shared -o bin/lib-iotics-id-sdk-amd64.so ${GO_SRC}
+	@env GOOS=$(OS_FLAG) GOARCH=$(ARCH_FLAG) go build -buildmode=c-shared -o bin/lib-iotics-id-sdk-amd64.so ${GO_SRC}
 
 so: clean compile

--- a/ffi/Makefile
+++ b/ffi/Makefile
@@ -20,6 +20,6 @@ clean:
 GO_SRC=./ffi_wrapper.go
 
 compile:
-	@env GOOS=$(OS_FLAG) GOARCH=$(ARCH_FLAG) go build -buildmode=c-shared -o bin/lib-iotics-id-sdk-amd64.so ${GO_SRC}
+	@env GOOS=$(OS_FLAG) GOARCH=$(ARCH_FLAG) go build -buildmode=c-shared -o bin/lib-iotics-id-sdk-$(ARCH_FLAG).so ${GO_SRC}
 
 so: clean compile


### PR DESCRIPTION
The Java FFI POC Makefile is hard-coded to support Linux/amd64.  To compile the shared library on macOS requires manual editing.

This PR detects the architecture and operating system within the Makefile.