### PR TITLE
FFI library Makefile improvements

### DIFF
--- a/ffi/Makefile
+++ b/ffi/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := compile_task
+
 ifeq ($(OS),Windows_NT)
     OS_FLAG=windows
     ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)

--- a/ffi/Makefile
+++ b/ffi/Makefile
@@ -38,6 +38,6 @@ clean:
 GO_SRC=./ffi_wrapper.go
 
 compile_task:
-	@env GOOS=${OS_FLAG} GOARCH=${ARCH_FLAG} go build -buildmode=c-shared -o lib/lib-iotics-id-sdk.${OS_EXT} ${GO_SRC}
+	@env GOOS=${OS_FLAG} GOARCH=${ARCH_FLAG} go build -x -buildmode=c-shared -o lib/lib-iotics-id-sdk.${OS_EXT} ${GO_SRC}
 
 compile: clean compile_task


### PR DESCRIPTION
Subtle improvements to the Makefile:

1. When running 'make', the first target, 'clean', is executed, which removes previously compiled code silently, which may not be what we want.  .DEFAULT_GOAL is set in this PR to execute the 'compile_task' target, which is more in line with what I'd expect as a user who hasn't read the README
2. The 'compile_task' target does not output anything when executing, which appears confusing because there's no indication of success or otherwise.  The '-x' flag has been added to 'go build' to display output