### PR TITLE
EI-1117 - Allow for reusable delegation proof

### DIFF
--- a/features/advanced_identity_api.feature
+++ b/features/advanced_identity_api.feature
@@ -85,6 +85,14 @@ Background:
     Then the delegated registered identity is allowed for control on the document
 
   @advanced_api
+  Scenario: Add a generic control delegation proof to a document
+    Given a registered identity with name "#IDA"
+    And a another registered identity with name "#IDB"
+    And a generic delegation proof created by "#IDB"
+    When I add the generic control delegation proof "#DelegFromProof" to the document
+    Then the delegated registered identity is allowed for control on the document
+
+  @advanced_api
   Scenario: Remove a control delegation proof from a register document
     Given a registered identity with name "#IDA"
     And a another registered identity with name "#IDB"
@@ -115,6 +123,14 @@ Background:
     And a another registered identity with name "#IDB"
     And a delegation proof for document of "#IDA" created by "#IDB"
     When I add the authentication delegation proof "#DelegFromProof" to the document
+    Then the other identity is allowed for authentication on the initial identity document
+
+  @advanced_api
+  Scenario: Add an generic authentication delegation proof to a document
+    Given a registered identity with name "#IDA"
+    And a another registered identity with name "#IDB"
+    And a generic delegation proof created by "#IDB"
+    When I add the generic authentication delegation proof "#DelegFromProof" to the document
     Then the other identity is allowed for authentication on the initial identity document
 
   @advanced_api

--- a/pkg/api/highLevelApi.go
+++ b/pkg/api/highLevelApi.go
@@ -176,7 +176,7 @@ func TakeOwnershipOfTwinAndDelegateControlByPrivateExponentHex(resolverClient re
 	opts := []register.RegisterDocumentOpts{
 		register.AddFromExistingDocument(twinDoc),
 		register.AddPublicKey(newOwnerKeyName, newOwnerID.KeyPair().PublicKeyBase58, false),
-		register.AddControlDelegation(delegationName, newOwnerID.Issuer().String(), dProof.Signature, false),
+		register.AddControlDelegation(delegationName, newOwnerID.Issuer().String(), dProof.Signature, register.DidProof, false),
 	}
 	updatedDoc, errs := register.NewRegisterDocument(opts)
 	if len(errs) != 0 {

--- a/pkg/register/document.go
+++ b/pkg/register/document.go
@@ -44,10 +44,11 @@ type RegisterPublicKey struct {
 
 // RegisterDelegationProof structure on delegation.
 type RegisterDelegationProof struct {
-	ID         string `json:"id"`
-	Controller string `json:"controller"`
-	Proof      string `json:"proof"`
-	Revoked    bool   `json:"revoked,omitempty"`
+	ID         string              `json:"id"`
+	Controller string              `json:"controller"`
+	Proof      string              `json:"proof"`
+	ProofType  DelegationProofType `json:"proofType,omitempty"`
+	Revoked    bool                `json:"revoked,omitempty"`
 }
 
 // RegisterDocument structure for document data.

--- a/pkg/register/documentBuilder.go
+++ b/pkg/register/documentBuilder.go
@@ -229,10 +229,10 @@ func AddAuthenticationKeyObj(obj *RegisterPublicKey) RegisterDocumentOpts {
 
 // AddControlDelegation returns a function which will add control delegation to the RegisterDocument
 // this function is idempotent, so if the same key (with the same name/ID) is added, it overwrites the previous one
-func AddControlDelegation(name string, controller string, proof string, revoked bool) RegisterDocumentOpts {
+func AddControlDelegation(name string, controller string, proof string, proofType DelegationProofType, revoked bool) RegisterDocumentOpts {
 	return func(builder *RegisterDocumentBuilder) error {
 		// NOTE: this is different to the Python version, which is not idempotent but raises an error
-		obj, err := NewRegisterDelegationProof(name, controller, proof, revoked)
+		obj, err := NewRegisterDelegationProof(name, controller, proof, proofType, revoked)
 		if err != nil {
 			return err
 		}
@@ -258,10 +258,10 @@ func AddControlDelegationObj(obj *RegisterDelegationProof) RegisterDocumentOpts 
 
 // AddAuthenticationDelegation returns a function which will add authentication delegation to the RegisterDocument
 // this function is idempotent, so if the same key (with the same name/ID) is added, it overwrites the previous one
-func AddAuthenticationDelegation(name string, controller string, proof string, revoked bool) RegisterDocumentOpts {
+func AddAuthenticationDelegation(name string, controller string, proof string, proofType DelegationProofType, revoked bool) RegisterDocumentOpts {
 	return func(builder *RegisterDocumentBuilder) error {
 		// NOTE: this is different to the Python version, which is not idempotent but raises an error
-		obj, err := NewRegisterDelegationProof(name, controller, proof, revoked)
+		obj, err := NewRegisterDelegationProof(name, controller, proof, proofType, revoked)
 		if err != nil {
 			return err
 		}

--- a/pkg/register/registerDelegationProof_test.go
+++ b/pkg/register/registerDelegationProof_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) IOTIC LABS LIMITED. All rights reserved. Licensed under the Apache License, Version 2.0.
+
+package register_test
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/Iotic-Labs/iotics-identity-go/pkg/proof"
+	"github.com/Iotic-Labs/iotics-identity-go/pkg/register"
+	"github.com/Iotic-Labs/iotics-identity-go/pkg/test"
+)
+
+func Test_validate_delegation_fails_if_invalid_controller_issuer(t *testing.T) {
+	invalidRegisteredProof := &register.RegisterDelegationProof{
+		Controller: "notAnIssuer",
+	}
+	err := register.ValidateDelegation(nil, "registeredDid", invalidRegisteredProof)
+	assert.ErrorContains(t, err, "invalid issuer string")
+}
+
+func Test_validate_delegation_fails_if_can_not_get_controller_doc(t *testing.T) {
+	invalidRegisteredProof := &register.RegisterDelegationProof{
+		Controller: "did:iotics:iotTdY27bo6ycsVs49T35QuPHZfjrJ3P41NR#user-name",
+	}
+	resolver := test.NewInMemoryResolver()
+	err := register.ValidateDelegation(resolver, "registeredDid", invalidRegisteredProof)
+	assert.ErrorContains(t, err, "document not found")
+}
+
+func Test_validate_delegation_fails_controller_public_key_not_found(t *testing.T) {
+	controllerDoc, _, _ := test.HelperGetRegisterDocument()
+	registeredProof := &register.RegisterDelegationProof{
+		Controller: "did:iotics:iotTdY27bo6ycsVs49T35QuPHZfjrJ3P41NR#different-issuer",
+	}
+	resolver := test.NewInMemoryResolver(controllerDoc)
+	err := register.ValidateDelegation(resolver, "registeredDid", registeredProof)
+	assert.ErrorContains(t, err, "controller public key #different-issuer not found")
+}
+
+func Test_validate_delegation_fails_if_content_does_not_match_proof_type(t *testing.T) {
+	type params struct {
+		proofType register.DelegationProofType
+		content []byte
+	}
+	registeredDID := "did:aregisteredDID"
+	for name, params := range map[string]params{
+		"invalid did content": {register.DidProof, []byte("")},
+		"invalid generic content": {register.GenericProof, []byte(registeredDID)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			controllerDoc, issuer, keyPair := test.HelperGetRegisterDocument()
+			cryptoProof, err := proof.NewProof(keyPair.PrivateKey, issuer.Did, issuer.Name, params.content)
+			assert.NilError(t, err)
+			registeredProof, err := register.NewRegisterDelegationProof("#ProofName", issuer.String(), cryptoProof.Signature, params.proofType, false)
+			assert.NilError(t, err)
+			resolver := test.NewInMemoryResolver(controllerDoc)
+			err = register.ValidateDelegation(resolver, registeredDID, registeredProof)
+			assert.ErrorContains(t, err, "invalid signature")
+		})
+	}
+}
+
+func Test_validate_delegation_succeeds_for_did_proof_type(t *testing.T) {
+	controllerDoc, issuer, keyPair := test.HelperGetRegisterDocument()
+	registeredDID := "did:aregisteredDID"
+	proofContent := []byte(registeredDID)
+
+	cryptoProof, err := proof.NewProof(keyPair.PrivateKey, issuer.Did, issuer.Name, proofContent)
+	assert.NilError(t, err)
+	registeredProof, err := register.NewRegisterDelegationProof("#ProofName", issuer.String(), cryptoProof.Signature, register.DidProof, false)
+	assert.NilError(t, err)
+	resolver := test.NewInMemoryResolver(controllerDoc)
+	err = register.ValidateDelegation(resolver, registeredDID, registeredProof)
+	assert.NilError(t, err)
+}
+
+func Test_validate_delegation_succeeds_for_generic_proof_type(t *testing.T) {
+	controllerDoc, issuer, keyPair := test.HelperGetRegisterDocument()
+	registeredDID := "did:aregisteredDID"
+	proofContent := []byte("")
+
+	cryptoProof, err := proof.NewProof(keyPair.PrivateKey, issuer.Did, issuer.Name, proofContent)
+	assert.NilError(t, err)
+	registeredProof, err := register.NewRegisterDelegationProof("#ProofName", issuer.String(), cryptoProof.Signature, register.GenericProof, false)
+	assert.NilError(t, err)
+	resolver := test.NewInMemoryResolver(controllerDoc)
+	err = register.ValidateDelegation(resolver, registeredDID, registeredProof)
+	assert.NilError(t, err)
+}
+
+func Test_validate_delegation_succeeds_for_unset_proof_type_backward_compatibility(t *testing.T) {
+	controllerDoc, issuer, keyPair := test.HelperGetRegisterDocument()
+	registeredDID := "did:aregisteredDID"
+	proofContent := []byte(registeredDID)
+	cryptoProof, err := proof.NewProof(keyPair.PrivateKey, issuer.Did, issuer.Name, proofContent)
+	assert.NilError(t, err)
+
+	registeredProof, err := register.NewRegisterDelegationProof("#ProofName", issuer.String(), cryptoProof.Signature, register.GenericProof, false)
+	assert.NilError(t, err)
+	registeredProof.ProofType = ""
+	resolver := test.NewInMemoryResolver(controllerDoc)
+	err = register.ValidateDelegation(resolver, registeredDID, registeredProof)
+	assert.NilError(t, err)
+}
+
+func Test_validate_delegation_fails_if_unknown_proof_type(t *testing.T) {
+	controllerDoc, issuer, keyPair := test.HelperGetRegisterDocument()
+	registeredDID := "did:aregisteredDID"
+	proofContent := []byte(registeredDID)
+	cryptoProof, err := proof.NewProof(keyPair.PrivateKey, issuer.Did, issuer.Name, proofContent)
+	assert.NilError(t, err)
+
+	registeredProof, err := register.NewRegisterDelegationProof("#ProofName", issuer.String(), cryptoProof.Signature, register.GenericProof, false)
+	assert.NilError(t, err)
+	registeredProof.ProofType = "unknown"
+	resolver := test.NewInMemoryResolver(controllerDoc)
+	err = register.ValidateDelegation(resolver, registeredDID, registeredProof)
+	assert.ErrorContains(t, err, "invalid proof type: unknown")
+}

--- a/pkg/register/registerPublicKey.go
+++ b/pkg/register/registerPublicKey.go
@@ -98,6 +98,7 @@ func convertReturnDelegationSliceToMap(slice []RegisterDelegationProof) map[stri
 			ID:         v.ID,
 			Controller: v.Controller,
 			Proof:      v.Proof,
+			ProofType:  v.ProofType,
 			Revoked:    v.Revoked,
 		}
 	}

--- a/pkg/test/examples.go
+++ b/pkg/test/examples.go
@@ -57,6 +57,8 @@ var (
 	ValidKeyPairPlop, _         = crypto.GetKeyPair(ValidKeyPairSecretsPlop)
 	ValidKeyPairSecretsPlop2, _ = crypto.NewKeyPairSecrets([]byte("d2397e8b83cf4a7073a26c1a1cdb6666"), "iotics/0/plop/plop1", crypto.SeedMethodBip39, "")
 	ValidKeyPairPlop2, _        = crypto.GetKeyPair(ValidKeyPairSecretsPlop2)
+	ValidKeyPairSecrets3, _ = crypto.NewKeyPairSecrets([]byte("d2397e8b83cf4a7073a26c1a1cdb6683"), "iotics/0/plop/plop3", crypto.SeedMethodBip39, "")
+	ValidKeyPair3, _        = crypto.GetKeyPair(ValidKeyPairSecrets3)
 
 	OtherDocDid, _    = identity.MakeIdentifier(ValidKeyPairPlop.PublicKeyBytes)
 	OtherDocIssuer, _ = register.NewIssuer(OtherDocDid, "#DelegatedDoc")


### PR DESCRIPTION
- New advanced helper to create a reusable delegation proof: `CreateReusableDelegationProof`
- `ValidateDelegation` fallback on reusable proof check if current case invalid
- `DelegateAuthentication` and `DelegateControl` keep using the single usage proof (default) but can use the reusable proof (new option)
- bdd + regular tests 
