### PR TITLE
Add .idea/ to .gitignore for JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ffi/java-idsdk/.idea
 ffi/java-idsdk/target
 ffi/java-idsdk/**/*.class
 dist/
+.idea/


### PR DESCRIPTION
This PR adds the .idea/ directory to .gitignore to allow easier development in JetBrains' [GoLand](https://www.jetbrains.com/go/) product